### PR TITLE
Add Google Sign-In meta tag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,8 @@
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
+  <!-- Google Sign-In meta tag for web client ID -->
+  <meta name="google-signin-client_id" content="357935783557-1376sq2pftj6slgsqen29sk4udvt4pt5.apps.googleusercontent.com" />
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- add google signin client id meta to fix web login error

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b6cdd6808320b86d8dc8cde269fb